### PR TITLE
Add support for OS X 64 bit platform

### DIFF
--- a/src/node_webkit_build/core.clj
+++ b/src/node_webkit_build/core.clj
@@ -10,7 +10,7 @@
             [com.github.bdesham.clj-plist :refer [parse-plist]]))
 
 (def default-options
-  {:platforms #{:osx :win :linux32 :linux64}
+  {:platforms #{:osx :osx64 :win :linux32 :linux64}
    :nw-version :latest
    :output "releases"
    :disable-developer-toolbar true
@@ -157,13 +157,23 @@
     (FileUtils/copyFile (io/file icon) (io/file resources-path "nw.icns")))
   build)
 
-(defmethod prepare-build :osx
+(defn osx-build
   [build req]
   (-> build
       (osx-copy-nw-contents req)
       (osx-inject-app-contents req)
       (osx-read-info-plist)
       (osx-icon req)))
+
+(defmethod prepare-build :osx
+  [build req]
+  (log :info "Preparing OS X 32 bit build")
+  (osx-build build req))
+
+(defmethod prepare-build :osx64
+  [build req]
+  (log :info "Preparing OS X 64 bit build")
+  (osx-build build req))
 
 ;; Windows Builder
 

--- a/src/node_webkit_build/versions.clj
+++ b/src/node_webkit_build/versions.clj
@@ -25,6 +25,7 @@
   (let [platform-sufix (condp = platform
                                 :win "win-ia32.zip"
                                 :osx "osx-ia32.zip"
+                                :osx64 "osx-x64.zip"
                                 :linux32 "linux-ia32.tar.gz"
                                 :linux64 "linux-x64.tar.gz")]
     (str "node-webkit-v" version "-" platform-sufix)))


### PR DESCRIPTION
I'm fairly sure I've updated everything necessary to add `:osx64` support. It might be a good idea to quickly check. You may also wish to update the `Readme.md`.

I've tested builds using the new `:osx64`, as well as the original `:osx` option. There are no build errors and the application seems to work fine.
