### PR TITLE
Only allow fully-released (non-alpha, non-RC) versions.

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject lein-node-webkit-build "0.1.8-SNAPSHOT"
+(defproject lein-node-webkit-build "0.1.7-SNAPSHOT"
   :description "Builder to pack node-webkit applicatons with leinigen"
   :url "https://github.com/wilkerlucio/lein-node-webkit-build"
   :license {:name "The MIT License"

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject lein-node-webkit-build "0.1.7-SNAPSHOT"
+(defproject lein-node-webkit-build "0.1.8-SNAPSHOT"
   :description "Builder to pack node-webkit applicatons with leinigen"
   :url "https://github.com/wilkerlucio/lein-node-webkit-build"
   :license {:name "The MIT License"

--- a/src/node_webkit_build/versions.clj
+++ b/src/node_webkit_build/versions.clj
@@ -15,7 +15,7 @@
    It uses clj-semver to sort the version numbers."
   (->> (http/get server-url)
        :body
-       (re-seq #"v(\d+\.\d+\.\d+)")
+       (re-seq #"v(\d+\.\d+\.\d+)/")
        (map second)
        (set)
        (sort semver/cmp)))


### PR DESCRIPTION
Fixes #7.

I tested this at the REPL and also by installing locally.  After making the change, download process works again.
