### PR TITLE
Small changes to allow for change in the executable (.app folder) name in v 0.12.0

### DIFF
--- a/src/node_webkit_build/core.clj
+++ b/src/node_webkit_build/core.clj
@@ -127,7 +127,8 @@
 ;; OSX Builder
 
 (defn osx-copy-nw-contents [{:keys [expanded-nw-package platform] :as build} {:keys [tmp-path] :as req}]
-  (let [app-path (path-join expanded-nw-package "node-webkit.app")
+  (let [nw-appname (versions/nw-appname (:nw-version req))
+        app-path (path-join expanded-nw-package (str nw-appname ".app"))
         output-path (path-join tmp-path "current" (name platform) (str (get-in req [:package :name]) ".app"))]
     (log :info (str "Copying " app-path " into " output-path))
     (io/copy-ensuring-blank app-path output-path)

--- a/src/node_webkit_build/versions.clj
+++ b/src/node_webkit_build/versions.clj
@@ -24,6 +24,11 @@
    :linux32 "linux-ia32.tar.gz"
    :linux64 "linux-x64.tar.gz"})
 
+(defn nw-appname [version]
+  (if (semver/older? version "0.12.0")
+    "node-webkit"
+    "nwjs"))
+
 (defn build-prefix [version]
   (if (semver/older? version "0.12.0")
     "node-webkit-v"

--- a/test/node_webkit_build/core_test.clj
+++ b/test/node_webkit_build/core_test.clj
@@ -8,7 +8,9 @@
             [taoensso.timbre :as timbre]))
 
 (def versions-list '("0.8.0" "0.8.1" "0.8.2" "0.8.3" "0.8.4" "0.8.5" "0.8.6" "0.8.7"
-                     "0.9.0" "0.9.1" "0.9.2" "0.9.3" "0.10.0" "0.10.1" "0.10.2"))
+                     "0.9.0" "0.9.1" "0.9.2" "0.9.3" "0.10.0" "0.10.1" "0.10.2"
+                      "0.10.3" "0.10.4" "0.10.5" "0.11.0" "0.11.1" "0.11.2" "0.11.3"
+                      "0.11.4" "0.11.5" "0.11.6" "0.12.0"))
 
 (timbre/set-level! :warn)
 
@@ -25,7 +27,7 @@
   (is (= "0.9.1"
          (:nw-version (normalize-version {:nw-version "0.9.1"
                                           :nw-available-versions versions-list}))))
-  (is (= "0.10.2"
+  (is (= "0.12.0"
          (:nw-version (normalize-version {:nw-version :latest
                                           :nw-available-versions versions-list})))))
 

--- a/test/node_webkit_build/core_test.clj
+++ b/test/node_webkit_build/core_test.clj
@@ -16,7 +16,9 @@
   (testing "read the version list and add into the request"
     (with-cassette :dl-node-webkit
       (is (= '("0.8.0" "0.8.1" "0.8.2" "0.8.3" "0.8.4" "0.8.5" "0.8.6" "0.8.7"
-               "0.9.0" "0.9.1" "0.9.2" "0.9.3" "0.10.0" "0.10.1" "0.10.2")
+               "0.9.0" "0.9.1" "0.9.2" "0.9.3" "0.10.0" "0.10.1" "0.10.2"
+                "0.10.3" "0.10.4" "0.10.5" "0.11.0" "0.11.1" "0.11.2" "0.11.3"
+                "0.11.4" "0.11.5" "0.11.6" "0.12.0")
              (:nw-available-versions (read-versions {})))))))
 
 (deftest test-normalize-version

--- a/test/node_webkit_build/versions_test.clj
+++ b/test/node_webkit_build/versions_test.clj
@@ -41,3 +41,9 @@
            (url-for :linux64 "0.9.1")))
     (is (= "http://dl.node-webkit.org/v0.12.0/nwjs-v0.12.0-osx-x64.zip"
            (url-for :osx64 "0.12.0")))))
+
+(deftest test-for-app-name-by-version
+  (testing "The executable names changed when semantic version switched up to 0.12.0"
+    (is (= "node-webkit" (nw-appname "0.8.0")))
+    (is (= "node-webkit" (nw-appname "0.11.6")))
+    (is (= "nwjs" (nw-appname "0.12.0")))))


### PR DESCRIPTION
I am using this for a project, and while the recent changes allow for the right download for v 0.12.0, the app was not being built as the node-webkit-build.core/osx-copy-nw-contents function used the hard-coded "node-webkit.app" folder on OSX. I tweaked it on the lines of the download-logic change using semver.

I believe this should affect OSX only, but I am not too sure and don't have access to another system. If you think this needs more work, please let me know and I'll be happy to do it.

Thanks for the plugin! :)