### PR TITLE
Correct references to the fs dependency

### DIFF
--- a/src/node_webkit_build/core.clj
+++ b/src/node_webkit_build/core.clj
@@ -6,7 +6,7 @@
             [taoensso.timbre :refer [log]]
             [node-webkit-build.versions :as versions]
             [node-webkit-build.io :refer [path-join] :as io]
-            [fs.core :as fs]
+            [me.raynes.fs :as fs]
             [node-webkit-build.util :as util]
             [com.github.bdesham.clj-plist :refer [parse-plist]]))
 

--- a/src/node_webkit_build/io.clj
+++ b/src/node_webkit_build/io.clj
@@ -3,8 +3,8 @@
            (org.apache.commons.io.input CountingInputStream)
            (org.apache.commons.io FilenameUtils FileUtils))
   (:require [clj-http.client :as http]
-            [fs.core :as fs]
-            [fs.compression :as compression]
+            [me.raynes.fs :as fs]
+            [me.raynes.fs.compression :as compression]
             [clojure.java.io :as io]
             [clojure.java.shell :refer [sh with-sh-dir]]
             [node-webkit-build.util :refer [insert-after print-progress-bar]]))


### PR DESCRIPTION
When I wanted to use this plugin, I got errors from the Clojure compiler because the namespace names for the filesystem utility library were not correct.