### PR TITLE
Make tests more independent of their ordering

### DIFF
--- a/test/node_webkit_build/core_test.clj
+++ b/test/node_webkit_build/core_test.clj
@@ -142,6 +142,7 @@
                         "CFBundleIdentifier" "com.intel.nw"}))))
 
 (deftest test-osx-export-plist
+  (io/mkdirs "tmp")
   (osx-export-plist {:contents-path "tmp"
                      :info {"CFBundleDisplayName" "App Name"}})
   (is (= (slurp "tmp/Info.plist")


### PR DESCRIPTION
`test-osx-export-plist` depended on the `tmp` directory
already being there, but it only gets created by `test-osx-icon`.

Note that this is only a quick fix. I noticed this bug when I first ran the tests. The second run went through smoothly. Normally the tests shouldn't "litter" the working directory like that or at least clean up afterwards, I think.